### PR TITLE
Update makeHTTPCallCPE.html

### DIFF
--- a/flow_action_components/HTTPBuilder/force-app/main/default/lwc/makeHTTPCallCPE/makeHTTPCallCPE.html
+++ b/flow_action_components/HTTPBuilder/force-app/main/default/lwc/makeHTTPCallCPE/makeHTTPCallCPE.html
@@ -55,7 +55,7 @@
         label={labels.Body_Label} 
         builder-context={_builderContext} 
         name="Body"  
-        onvaluechanged={handleFlowComboboxValueChange} 
+        onvaluechanged={changeBody} 
         value={body} 
         value-type={bodyType} 
         class="slds-m-around_medium"
@@ -84,7 +84,7 @@
         </div>
     </template>
 
-    <template if:true={isShowMergeFeildReplacer}>
+    <template if:false={isShowMergeFeildReplacer}>
         <c-merge-field-replacer merge-field-list={mergeFieldList} onclosemodal={closeMergeFieldReplacer}>
 
         </c-merge-field-replacer>


### PR DESCRIPTION
Fixed onChange and removed isShowMergeFeildReplacer from popping up on POST methods, allowing variables to be used from flow resources as the setBody of a POST request. This is my first pull request so please let me know if I've done something wrong. I also have a pull request I'll propose after this one to the js file.